### PR TITLE
fix: transaction service에서 걸리도록 구성

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/service/ChatConsumeService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/service/ChatConsumeService.java
@@ -2,7 +2,6 @@ package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.service;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.transaction.Transactional;
 import java.time.Duration;
 import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.dto.consume.ChatConsumeDto;
 import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.dto.mapping.ChatDtoMapping;
@@ -19,9 +18,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ChatConsumeService {
 
@@ -38,7 +39,6 @@ public class ChatConsumeService {
 
 
     @KafkaListener(topics = "chat")
-    @Transactional
     public void handleChatMessage(String chatMessage) {
         try {
             ChatConsumeDto chatDto = objectMapper.readValue(chatMessage, ChatConsumeDto.class);

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/service/RelayService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/service/RelayService.java
@@ -9,9 +9,11 @@ import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.user.entity.Use
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class RelayService {
 


### PR DESCRIPTION
## ☝️ 요약

transaction service에서 걸리도록 구성

## ✏️ 상세 내용

일 부분 service에서 transaction을 보장하지 않는 부분이 있다.
service 에서 모든 로직에 transaction을 보장하도록 한다.

service 단에서 repository를 한번만 접근해서 지금은 트랜잭션을 보장하는 부분도 있다.
하지만 코드 명확성을 위해 해당 service단도 transaction을 선언한다.

## ✅ 체크리스트

- [x] service 단에서 모두 transaction을 선언한다.
