### PR TITLE
refactor: dto 생성자 방식에서 record로 변경

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/dto/consume/ChatConsumeDto.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/dto/consume/ChatConsumeDto.java
@@ -1,20 +1,12 @@
 package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.dto.consume;
 
-import lombok.Getter;
+import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.common.type.ChatStatus;
 
-@Getter
-public class ChatConsumeDto {
-    private final String idempotentKey;
-    private final Long senderId;
-    private final Long receiverId;
-    private final String content;
-    private final String status;
-
-    public ChatConsumeDto(String idempotentKey, Long senderId, Long receiverId, String content, String status) {
-        this.idempotentKey = idempotentKey;
-        this.senderId = senderId;
-        this.receiverId = receiverId;
-        this.content = content;
-        this.status = status;
-    }
+public record ChatConsumeDto(
+        String idempotentKey,
+        Long senderId,
+        Long receiverId,
+        String content,
+        ChatStatus status
+) {
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/dto/mapping/ChatDtoMapping.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/dto/mapping/ChatDtoMapping.java
@@ -7,9 +7,9 @@ public class ChatDtoMapping {
 
     public static ChatRelayDto consumeToRelay(ChatConsumeDto consumeDto) {
         return new ChatRelayDto(
-                consumeDto.getSenderId(),
-                consumeDto.getReceiverId(),
-                consumeDto.getContent()
+                consumeDto.senderId(),
+                consumeDto.receiverId(),
+                consumeDto.content()
         );
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/dto/relay/ChatRelayDto.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/dto/relay/ChatRelayDto.java
@@ -1,16 +1,8 @@
 package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.dto.relay;
 
-import lombok.Getter;
-
-@Getter
-public class ChatRelayDto {
-    private final Long senderId;
-    private final Long receiverId;
-    private final String content;
-
-    public ChatRelayDto(Long senderId, Long receiverId, String content) {
-        this.senderId = senderId;
-        this.receiverId = receiverId;
-        this.content = content;
-    }
+public record ChatRelayDto(
+        Long senderId,
+        Long receiverId,
+        String content
+) {
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/common/type/ChatStatus.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/common/type/ChatStatus.java
@@ -1,0 +1,5 @@
+package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.common.type;
+
+public enum ChatStatus {
+    SENT
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/global/config/KafkaConfig.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/global/config/KafkaConfig.java
@@ -5,16 +5,22 @@ import java.util.Map;
 import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.dto.consume.ChatConsumeDto;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 
 @Configuration
@@ -46,8 +52,20 @@ public class KafkaConfig {
     }
 
     @Bean
-    public KafkaTemplate<String, ChatConsumeDto> chatMessageKafkaTemplate() {
+    public KafkaTemplate<String, ChatConsumeDto> chatMessageKafkaProducerTemplate() {
         return new KafkaTemplate<>(chatMessageProducerFactory());
+    }
+
+    @Bean
+    public ConsumerFactory<String, ChatConsumeDto> chatMessageConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "chat-consumer-group");
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, ChatConsumeDto.class.getName());
+        return new DefaultKafkaConsumerFactory<>(props);
     }
 
     @Bean
@@ -56,6 +74,14 @@ public class KafkaConfig {
                 .partitions(partitions_cnt)
                 .replicas(replicas_cnt)
                 .build();
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ChatConsumeDto> chatMessageContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ChatConsumeDto> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(chatMessageConsumerFactory());
+        return factory;
     }
 
 }


### PR DESCRIPTION
## ☝️ 요약

dto 생성자 방식에서 record로 변경

## ✏️ 상세 내용

카프카 Listener에서 파라미터로 DTO를 바로 주입받을 수 있도록 변경.
일반적인 Class DTO를 사용할 경우 JsonCreator 까지 구현하거나, @Setter를 사용해야 한다.

record는 이를 구현할 필요없이 바로 DTO로 주입받을 수 있다.
record를 사용한다.

## ✅ 체크리스트

- [x] 채팅이 정상적으로 동작하는지 확인하였습니다.