### PR TITLE
hotfix: 레디스에 접속한 채팅방의 정보에 따라 relay 요청을 보내도록 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 /src/main/resources/application-dev.properties
 /src/main/resources/application-prod.properties
 /src/main/resources/application-stage.properties
+/src/test/resources/application.properties

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/adapter/in/kafka/ChatConsumeService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/adapter/in/kafka/ChatConsumeService.java
@@ -1,14 +1,14 @@
-package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in;
+package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.kafka;
 
 
-import static kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.exception.InvalidChatEventStatusException.MESSAGE_INVALID_STATUS;
+import static kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.kafka.exception.InvalidChatEventStatusException.MESSAGE_INVALID_STATUS;
 import static kakaotech.bootcamp.respec.specranking.chatconsumer.domain.user.exception.UserNotFoundException.MESSAGE_USER_NOT_FOUND;
 import static kakaotech.bootcamp.respec.specranking.chatconsumer.global.common.type.ChatStatus.SENT;
 
 import java.time.Duration;
-import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.Event.ChatConsumeEvent;
-import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.exception.InvalidChatEventStatusException;
-import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.mapping.ChatDtoMapping;
+import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.kafka.Event.ChatConsumeEvent;
+import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.kafka.exception.InvalidChatEventStatusException;
+import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.kafka.mapping.ChatDtoMapping;
 import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.entity.Chat;
 import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.repository.ChatRepository;
 import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.service.ChatRelayService;

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/adapter/in/kafka/Event/ChatConsumeEvent.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/adapter/in/kafka/Event/ChatConsumeEvent.java
@@ -1,4 +1,4 @@
-package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.Event;
+package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.kafka.Event;
 
 import kakaotech.bootcamp.respec.specranking.chatconsumer.global.common.type.ChatStatus;
 

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/adapter/in/kafka/exception/ChatEventException.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/adapter/in/kafka/exception/ChatEventException.java
@@ -1,4 +1,4 @@
-package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.exception;
+package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.kafka.exception;
 
 public class ChatEventException extends RuntimeException {
     public ChatEventException(String message) {

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/adapter/in/kafka/exception/InvalidChatEventStatusException.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/adapter/in/kafka/exception/InvalidChatEventStatusException.java
@@ -1,4 +1,4 @@
-package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.exception;
+package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.kafka.exception;
 
 public class InvalidChatEventStatusException extends ChatEventException {
 

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/adapter/in/kafka/mapping/ChatDtoMapping.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/adapter/in/kafka/mapping/ChatDtoMapping.java
@@ -1,6 +1,6 @@
-package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.mapping;
+package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.kafka.mapping;
 
-import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.Event.ChatConsumeEvent;
+import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.kafka.Event.ChatConsumeEvent;
 import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.dto.ChatRelayDto;
 
 public class ChatDtoMapping {

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/adapter/in/redis/dto/ChatSessionRedisValue.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/adapter/in/redis/dto/ChatSessionRedisValue.java
@@ -1,0 +1,7 @@
+package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.redis.dto;
+
+public record ChatSessionRedisValue(
+        String privateAddress,
+        Long partnerId
+) {
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/service/ChatRelayService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/domain/chat/service/ChatRelayService.java
@@ -2,6 +2,8 @@ package kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.service;
 
 import static kakaotech.bootcamp.respec.specranking.chatconsumer.global.common.type.NotificationTargetType.CHAT;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.redis.dto.ChatSessionRedisValue;
 import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.dto.ChatRelayDto;
 import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.notification.entity.Notification;
 import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.notification.repository.NotificationRepository;
@@ -17,18 +19,22 @@ import org.springframework.web.reactive.function.client.WebClient;
 @RequiredArgsConstructor
 public class ChatRelayService {
 
-    private final RedisTemplate<String, Object> redisTemplate;
-    private final WebClient webClient;
-    private final NotificationRepository notificationRepository;
-
     private static final String REDIS_USER_KEY_PREFIX = "chat:user:";
     private static final String CHAT_RELAY_API_PATH = "/api/chat/relay";
     private static final String SCHEME = "http://";
 
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final WebClient webClient;
+    private final NotificationRepository notificationRepository;
+    private final ObjectMapper objectMapper;
+
     public void relayOrNotify(User receiver, ChatRelayDto dto) {
         Object serverIpObj = redisTemplate.opsForValue().get(REDIS_USER_KEY_PREFIX + receiver.getId());
+        ChatSessionRedisValue chatSessionRedisValue = objectMapper.convertValue(serverIpObj,
+                ChatSessionRedisValue.class);
 
-        if (serverIpObj instanceof String serverIp && !serverIp.isEmpty()) {
+        if (chatSessionRedisValue != null && chatSessionRedisValue.partnerId().equals(receiver.getId())) {
+            final String serverIp = chatSessionRedisValue.privateAddress();
             webClient.post()
                     .uri(SCHEME + serverIp + CHAT_RELAY_API_PATH)
                     .bodyValue(dto)

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/global/infrastructure/kafka/config/KafkaConfig.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/global/infrastructure/kafka/config/KafkaConfig.java
@@ -2,7 +2,7 @@ package kakaotech.bootcamp.respec.specranking.chatconsumer.global.infrastructure
 
 import java.util.HashMap;
 import java.util.Map;
-import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.Event.ChatConsumeEvent;
+import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.kafka.Event.ChatConsumeEvent;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/global/infrastructure/kafka/config/KafkaConfig.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/chatconsumer/global/infrastructure/kafka/config/KafkaConfig.java
@@ -1,15 +1,19 @@
 package kakaotech.bootcamp.respec.specranking.chatconsumer.global.infrastructure.kafka.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import kakaotech.bootcamp.respec.specranking.chatconsumer.domain.chat.adapter.in.kafka.Event.ChatConsumeEvent;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,13 +25,14 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
-import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.util.backoff.FixedBackOff;
 
 @Configuration
+@Slf4j
 public class KafkaConfig {
 
     @Value("${spring.kafka.bootstrap-servers}")
@@ -78,13 +83,57 @@ public class KafkaConfig {
     }
 
     @Bean
-    public DefaultErrorHandler kafkaErrorHandler() {
-        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
-                dlqProducerTemplate(),
-                (r, e) -> new TopicPartition("chat-dlt", r.partition())
-        );
+    public ProducerFactory<String, Object> objectDlqProducerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
 
-        return new DefaultErrorHandler(recoverer, new FixedBackOff(1000L, 3L));
+    @Bean
+    public KafkaTemplate<String, Object> objectDlqTemplate() {
+        return new KafkaTemplate<>(objectDlqProducerFactory());
+    }
+
+    @Bean
+    public DefaultErrorHandler kafkaErrorHandler() {
+        return new DefaultErrorHandler((record, exception) -> {
+            final String dlqTopic = "chat-dlt";
+            final int partition = record.partition();
+
+            if (record.key() instanceof byte[] && record.value() instanceof byte[]) {
+                ProducerRecord<byte[], byte[]> outRecord = new ProducerRecord<>(
+                        dlqTopic, partition, (byte[]) record.key(), (byte[]) record.value()
+                );
+
+                outRecord.headers().add("key-type", "byte[]".getBytes(StandardCharsets.UTF_8));
+                outRecord.headers().add("value-type", "byte[]".getBytes(StandardCharsets.UTF_8));
+                outRecord.headers().add("error-type", "DESERIALIZATION_ERROR".getBytes(StandardCharsets.UTF_8));
+
+                dlqProducerTemplate().send(outRecord);
+            } else if (record.key() instanceof String && record.value() instanceof ChatConsumeEvent) {
+                try {
+                    ObjectMapper mapper = new ObjectMapper();
+                    byte[] keyBytes = mapper.writeValueAsBytes(record.key());
+                    byte[] valueBytes = mapper.writeValueAsBytes(record.value());
+                    
+                    ProducerRecord<byte[], byte[]> outRecord = new ProducerRecord<>(
+                            dlqTopic, partition, keyBytes, valueBytes
+                    );
+
+                    outRecord.headers().add("key-type", "String".getBytes(StandardCharsets.UTF_8));
+                    outRecord.headers().add("value-type", "ChatConsumeEvent".getBytes(StandardCharsets.UTF_8));
+                    outRecord.headers().add("error-type", "RUNTIME_ERROR".getBytes(StandardCharsets.UTF_8));
+
+                    dlqProducerTemplate().send(outRecord);
+                } catch (Exception e) {
+                    log.error("ChatConsumeEvent Byte 직렬화 과정에서 오류가 발생했습니다.", e);
+                }
+            } else {
+                log.error("DefaultErrorHandler에 등록되지 않은 type이 Consume 되고, Runtime 에러 발생 했습니다.", exception);
+            }
+        }, new FixedBackOff(1000L, 3L));
     }
 
     @Bean


### PR DESCRIPTION
## ☝️ 요약

레디스에 접속한 채팅방의 정보에 따라 relay 요청을 보내도록 수정

## ✏️ 상세 내용

레디스에 접속한 user 정보에 따라 relay 요청, 알림 생성 중 하나를 선택한다. user가 접속해 있더라도 sender가 보내는 채팅에 접속해 있지 않으면 relay 요청이 아닌 알림을 생성해야한다. 따라서 해당 채팅방의 정보 (접속해 있는 채팅방의 sender 정보)를 redis에 넣어야 consumer가 판단 가능하다. (메인 서버에서 해당 부분 로직 개발 완료)

이 redis 정보를 이용하여 relay 요청을 보낼지 말지, 분기 로직을 작성한다.

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 정상적으로 동작하는지 확인했습니다.